### PR TITLE
refactor: restore single god form wrapping all command actions

### DIFF
--- a/src/main/webapp/todos.xhtml
+++ b/src/main/webapp/todos.xhtml
@@ -11,15 +11,15 @@
     <ui:define name="pageTitle"> TODO LIST</ui:define>
     <ui:define name="content">
 
-        <!-- Section 1: Summary / Filter Buttons -->
-        <div faces:id="filterPanel">
-            <form faces:id="filterForm" role="form" class="form">
+        <form faces:id="mainForm" role="form" class="form">
+            <!-- Section 1: Summary / Filter Buttons -->
+            <div faces:id="filterPanel">
                 <div class="row g-3 mb-4">
                     <div class="col-md-4">
                         <a faces:id="filterAll"
                            faces:action="#{todoList.changeFilter('ALL')}"
                            class="text-decoration-none">
-                            <f:ajax execute="@this" render=":filterPanel :todoListPanel :alertPanel"/>
+                            <f:ajax execute="@this" render="@form :alertPanel"/>
                             <div class="card border-primary #{todoList.filter == 'ALL' ? 'bg-primary text-white shadow' : 'bg-light text-primary border-opacity-50'} text-center p-3 hover-shadow cursor-pointer transition-all">
                                 <div class="fs-6 fw-bold text-uppercase tracking-wider mb-1">ALL</div>
                                 <div class="display-6 fw-bold">#{todoList.allCount}</div>
@@ -30,7 +30,7 @@
                         <a faces:id="filterPending"
                            faces:action="#{todoList.changeFilter('PENDING')}"
                            class="text-decoration-none">
-                            <f:ajax execute="@this" render=":filterPanel :todoListPanel :alertPanel"/>
+                            <f:ajax execute="@this" render="@form :alertPanel"/>
                             <div class="card border-warning #{todoList.filter == 'PENDING' ? 'bg-warning text-dark shadow' : 'bg-light text-warning border-opacity-50'} text-center p-3 hover-shadow cursor-pointer transition-all">
                                 <div class="fs-6 fw-bold text-uppercase tracking-wider mb-1">PENDING</div>
                                 <div class="display-6 fw-bold">#{todoList.pendingCount}</div>
@@ -41,7 +41,7 @@
                         <a faces:id="filterCompleted"
                            faces:action="#{todoList.changeFilter('COMPLETED')}"
                            class="text-decoration-none">
-                            <f:ajax execute="@this" render=":filterPanel :todoListPanel :alertPanel"/>
+                            <f:ajax execute="@this" render="@form :alertPanel"/>
                             <div class="card border-success #{todoList.filter == 'COMPLETED' ? 'bg-success text-white shadow' : 'bg-light text-success border-opacity-50'} text-center p-3 hover-shadow cursor-pointer transition-all">
                                 <div class="fs-6 fw-bold text-uppercase tracking-wider mb-1">COMPLETED</div>
                                 <div class="display-6 fw-bold">#{todoList.completedCount}</div>
@@ -49,8 +49,7 @@
                         </a>
                     </div>
                 </div>
-            </form>
-        </div>
+            </div>
 
         <!-- Section 2: Todo Form (Add / Update) -->
         <div faces:id="todoFormPanel" class="card mb-4 shadow-sm border-0 bg-white">
@@ -60,30 +59,27 @@
                     #{todoList.form.id == null ? 'Add a New Todo' : 'Update Todo Item'}
                 </h5>
                 <ui:fragment rendered="#{todoList.form.id != null}">
-                    <form faces:id="cancelEditForm">
-                        <a faces:id="cancelEdit"
+                    <a faces:id="cancelEdit"
                            faces:action="#{todoList.cancelEdit()}"
                            class="btn btn-sm btn-outline-light">
-                            <f:ajax execute="@this" render=":todoFormPanel :alertPanel"/>
+                            <f:ajax execute="@this" render="@form :alertPanel"/>
                             Cancel Edit
-                        </a>
-                    </form>
+                    </a>
                 </ui:fragment>
             </div>
             <div class="card-body p-4 bg-light bg-opacity-50">
-                <form faces:id="todoForm" role="form" class="form">
-                    <div class="row g-3 align-items-center">
+                <div class="row g-3 align-items-center">
                         <div class="col-md-9 col-sm-12">
                             <div class="form-floating">
                                 <input type="text" faces:id="title"
-                                       class="form-control #{not empty facesContext.getMessageList('todoForm:title') ? 'is-invalid' : ''}"
+                                       class="form-control #{not empty facesContext.getMessageList('mainForm:title') ? 'is-invalid' : ''}"
                                        faces:value="#{todoList.form.title}"
                                        faces:required="true"
                                        faces:requiredMessage="Todo title is required."
                                        placeholder="What needs to be done?"/>
-                                <label for="todoForm:title" class="text-secondary">What needs to be done?</label>
+                                <label for="mainForm:title" class="text-secondary">What needs to be done?</label>
                                 <small class="invalid-feedback fw-bold">
-                                    <h:message for="todoForm:title" showDetail="false" showSummary="true"/>
+                                    <h:message for="title" showDetail="false" showSummary="true"/>
                                 </small>
                             </div>
                         </div>
@@ -93,12 +89,11 @@
                                     faces:action="#{todoList.saveTodo()}"
                                     class="btn #{todoList.form.id == null ? 'btn-primary' : 'btn-success'} btn-lg w-100 py-3 fw-bold">
                                 <f:ajax execute="@form"
-                                        render=":filterPanel :todoFormPanel :todoListPanel :alertPanel"/>
+                                        render="@form :alertPanel"/>
                                 #{todoList.form.id == null ? 'Add Todo' : 'Update Todo'}
                             </button>
                         </div>
                     </div>
-                </form>
             </div>
         </div>
 
@@ -116,7 +111,6 @@
             <div class="card-body p-0">
                 <ui:fragment rendered="#{not empty todoList.todos}">
                     <div class="list-group list-group-flush">
-                        <form faces:id="listForm" role="form" class="form">
                             <ui:repeat id="todos" var="todo" value="#{todoList.todos}">
                                 <div class="list-group-item d-flex align-items-center justify-content-between p-3 border-bottom hover-light transition-all">
                                     <div class="d-flex align-items-center flex-grow-1">
@@ -124,7 +118,7 @@
                                         <a faces:id="toggleStatus"
                                            faces:action="#{todoList.toggleCompletedStatus(todo.id)}"
                                            class="text-decoration-none d-flex align-items-center">
-                                            <f:ajax execute="@this" render=":filterPanel :todoListPanel :alertPanel"/>
+                                            <f:ajax execute="@this" render="@form :alertPanel"/>
                                             <input type="checkbox" class="form-check-input fs-5 me-3 cursor-pointer"
                                                    checked="#{todo.status == 'COMPLETED' ? 'checked' : null}"/>
                                         </a>
@@ -145,19 +139,18 @@
                                         <a faces:id="editTodo"
                                            faces:action="#{todoList.editTodo(todo.id)}"
                                            class="btn btn-sm btn-outline-primary" title="Edit Todo">
-                                            <f:ajax execute="@this" render=":todoFormPanel :todoListPanel :alertPanel"/>
+                                            <f:ajax execute="@this" render="@form :alertPanel"/>
                                             <i class="bi bi-pencil-square"></i>
                                         </a>
                                         <a faces:id="deleteTodo"
                                            faces:action="#{todoList.deleteTodo(todo.id)}"
                                            class="btn btn-sm btn-outline-danger" title="Delete Todo">
-                                            <f:ajax execute="@this" render=":filterPanel :todoListPanel :alertPanel"/>
+                                            <f:ajax execute="@this" render="@form :alertPanel"/>
                                             <i class="bi bi-trash"></i>
                                         </a>
                                     </div>
                                 </div>
                             </ui:repeat>
-                        </form>
                     </div>
                 </ui:fragment>
                 <ui:fragment rendered="#{empty todoList.todos}">
@@ -168,6 +161,8 @@
                 </ui:fragment>
             </div>
         </div>
+
+        </form>
 
     </ui:define>
 </ui:composition>


### PR DESCRIPTION
Merge 4 separate forms (filterForm, cancelEditForm, todoForm, listForm) into a single mainForm that wraps all UICommand components on the page. Update ajax render targets and message/label references accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)